### PR TITLE
Remove FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-github: Fuelviews

--- a/.github/funding.yml
+++ b/.github/funding.yml
@@ -1,1 +1,0 @@
-github: Fuelviews


### PR DESCRIPTION
Removes the `FUNDING.yml` and `funding.yml` files from the repository. 

**Motivation:**
The removal of these files is intended to streamline our project's configuration and reduce redundancy. Since both files contained identical information regarding funding sources, maintaining two separate files was unnecessary and could lead to confusion.

**Improvements:**
By consolidating our funding information, we simplify the repository structure and make it easier for contributors to understand our funding model. This change also helps us adhere to best practices by eliminating duplicate content, ultimately improving the maintainability of the project.