### PR TITLE
Replace dropdown blog links with a commented-out single link for articles and update logo shape configuration to separate default and transparency states. #MAJOR

### DIFF
--- a/config/navigation.php
+++ b/config/navigation.php
@@ -30,13 +30,13 @@ return [
             ],
         ],
 
-        // dropdown blog links
-        [
-            'type' => 'dropdown-blog',
-            'position' => 2,
-            'name' => 'Blog',
-            'enabled' => false,
-        ],
+        // single link
+        /*[
+            'type' => 'link',
+            'position' => 6,
+            'name' => 'Articles',
+            'route' => 'sabhero-article.post.index',
+        ],*/
     ],
 
     // scrolled routes
@@ -61,6 +61,7 @@ return [
     'logo_swap_enabled' => true,
     'transparent_nav_background' => true,
 
-    // footer stuff, needs to be moved to navigation config
-    'logo_shape' => 'horizontal', // Can be 'horizontal', 'vertical', or 'square'
+    // logo shape config
+    'default_logo_shape' => 'square', // Can be 'horizontal', 'vertical', or 'square'
+    'transparency_logo_shape' => 'horizontal', // Can be 'horizontal', 'vertical', or 'square'
 ];


### PR DESCRIPTION
**Summary of Changes:**

1. **Navigation Configuration Update:**
   - Removed the dropdown blog links configuration.
   - Added a commented-out single link configuration for "Articles" with a specified route.

2. **Logo Shape Configuration Update:**
   - Separated the logo shape configuration into two distinct states: `default_logo_shape` and `transparency_logo_shape`, allowing different shapes for default and transparent navigation backgrounds.