### PR TITLE
remove desktop scroll link transitions

### DIFF
--- a/resources/views/components/desktop/desktop-navigation-link.blade.php
+++ b/resources/views/components/desktop/desktop-navigation-link.blade.php
@@ -2,8 +2,8 @@
 
 @php
     $classes = ($active ?? false)
-        ? 'inline-flex items-center border-b-2 border-prime-400 text-sm font-medium leading-5 hover:text-gray-400 hover:border-gray-300 focus:outline-none focus:text-gray-700 focus:border-gray-300 transition duration-150 ease-in-out py-2 uppercase'
-        : 'inline-flex items-center border-b-2 border-transparent text-sm font-medium leading-5 hover:text-gray-400 hover:border-gray-300 focus:outline-none focus:text-gray-700 focus:border-gray-300 transition duration-150 ease-in-out py-2 uppercase';
+        ? 'inline-flex items-center border-b-2 border-prime-400 text-sm font-medium leading-5 hover:text-gray-400 hover:border-gray-300 focus:outline-none focus:text-gray-700 focus:border-gray-300 ease-in-out py-2 uppercase'
+        : 'inline-flex items-center border-b-2 border-transparent text-sm font-medium leading-5 hover:text-gray-400 hover:border-gray-300 focus:outline-none focus:text-gray-700 focus:border-gray-300 ease-in-out py-2 uppercase';
 @endphp
 
 <a {{ $attributes->merge(['class' => $classes]) }}>

--- a/resources/views/components/dropdown-link.blade.php
+++ b/resources/views/components/dropdown-link.blade.php
@@ -2,8 +2,8 @@
 
 @php
     $classes = ($active ?? false)
-        ? "block pl-4 px-4 py-2 border-l-4 text-sm border-prime-400 text-base font-medium text-gray-700 bg-gray-50 focus:outline-none focus:text-gray-800 focus:bg-gray-100 focus:border-gray-700 transition duration-150 ease-in-out first:rounded-tr-lg last:rounded-br-lg"
-        : "block w-full px-4 py-2 text-start text-sm leading-5 text-gray-700 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 transition duration-150 ease-in-out odd:bg-slate-100 first:rounded-t-lg last:rounded-b-lg";
+        ? "block pl-4 px-4 py-2 border-l-4 text-sm border-prime-400 text-base font-medium text-gray-700 bg-gray-50 focus:outline-none focus:text-gray-800 focus:bg-gray-100 focus:border-gray-700 ease-in-out first:rounded-tr-lg last:rounded-br-lg"
+        : "block w-full px-4 py-2 text-start text-sm leading-5 text-gray-700 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 ease-in-out odd:bg-slate-100 first:rounded-t-lg last:rounded-b-lg";
 @endphp
 
 <a {{ $attributes->merge(['class' => $classes]) }}>

--- a/resources/views/components/logo.blade.php
+++ b/resources/views/components/logo.blade.php
@@ -1,7 +1,7 @@
 @php
     $defaultLogoShape = Navigation::getDefaultLogoShape();
     $transparencyLogoShape = Navigation::getTransparencyLogoShape();
-    
+
     // Classes for default logo
     $defaultLogoClasses = '';
     if ($defaultLogoShape === 'horizontal') {
@@ -11,7 +11,7 @@
     } elseif ($defaultLogoShape === 'square') {
         $defaultLogoClasses = 'mx-auto w-24 lg:w-32';
     }
-    
+
     // Classes for transparency logo
     $transparencyLogoClasses = '';
     if ($transparencyLogoShape === 'horizontal') {


### PR DESCRIPTION
### Summary of Changes

1. **Removed Transition from Desktop Navigation Links:**
   - In `desktop-navigation-link.blade.php`, the `transition duration-150` class was removed from both active and inactive link styles to eliminate scroll link transitions on desktop navigation.

2. **Removed Transition from Dropdown Links:**
   - In `dropdown-link.blade.php`, the `transition duration-150` class was removed from both active and inactive dropdown link styles to remove transition effects.

3. **Code Formatting Adjustments:**
   - Minor whitespace adjustments were made in `logo.blade.php` to improve code readability and maintain consistency.