### PR TITLE
change hamburger color

### DIFF
--- a/resources/views/components/hamburger-button.blade.php
+++ b/resources/views/components/hamburger-button.blade.php
@@ -1,5 +1,5 @@
 <button @click="dropdownOpen = !dropdownOpen"
-        class="inline-flex items-center justify-center rounded-standard text-gray-900 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 focus:text-gray-500 transition duration-150 ease-in-out">
+        class="inline-flex items-center justify-center rounded-standard text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 focus:text-gray-500 transition duration-150 ease-in-out">
     <svg class="h-9 w-9" stroke="currentColor" fill="none" viewBox="0 0 24 24">
         <path :class="{'hidden': dropdownOpen, 'inline-flex': ! dropdownOpen }" class="inline-flex"
               stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/>


### PR DESCRIPTION
### Summary of Changes

- **File:** `resources/views/components/hamburger-button.blade.php`
  - Updated the default text color of the hamburger button from `text-gray-900` to `text-gray-400`.
  - This change affects the initial appearance of the button, making it appear lighter when not interacted with.